### PR TITLE
register file: explicitly use synchronous read RAM

### DIFF
--- a/boards/lattice/iCE40-UltraPlus-MDP/icecube2/src/mf8_reg.v
+++ b/boards/lattice/iCE40-UltraPlus-MDP/icecube2/src/mf8_reg.v
@@ -1,41 +1,66 @@
-module mf8_reg(Clk, Reset_n, Wr, Rd_Addr, Rr_Addr, Data_In, Rd_Data, Rr_Data, Z);
-	input			Clk;
-	input			Reset_n;
-	input			Wr;
-	input	[4:0]	Rd_Addr;
-	input	[4:0]	Rr_Addr;
-	input	[7:0]	Data_In;
-	output	[7:0]	Rd_Data;
-	reg	[7:0]	Rd_Data;		// appended automatically by vhdl2verilog.
-	output	[7:0]	Rr_Data;
-	reg	[7:0]	Rr_Data;		// appended automatically by vhdl2verilog.
-	output	[15:0]	Z;
-	reg	[15:0]	Z;		// appended automatically by vhdl2verilog.
+/*
+ * Copyright 2018 MicroFPGA UG
+ * Copyright 2019 The Regents of the University of California
+ * Apache 2.0 License
+ */
 
 
-	reg 	[7:0]	RegD	[31:0];
-	reg 	[7:0]	RegR	[31:0];
-	reg 	[4:0]	Rd_Addr_r;
+module mf8_reg(Clk, Reset, Wr, Rd_Addr, Rr_Addr, Data_In, Rd_Data, Rr_Data, Z);
+	input Clk;
+	input Reset;
+	input Wr;
+	input [4:0] Rd_Addr;
+	input [4:0] Rr_Addr;
+	input [7:0] Data_In;
+	output [7:0] Rd_Data;
+	output [7:0] Rr_Data;
+	output [15:0] Z;
+	reg    [15:0] Z;
+
+	// Write Address Buffer
+	reg [4:0] RAM_Write_Address;
+	always @(posedge Clk) begin
+		RAM_Write_Address <= Rd_Addr;
+	end
+
+	// RAM D
+	reg [7:0] RAMD [31:0];
+	reg [7:0] RAMD_Out;
 
 	always @(posedge Clk) begin
-		Rd_Addr_r	<= Rd_Addr;
-		Rd_Data	<= RegD[Rd_Addr];
-		Rr_Data	<= RegR[Rr_Addr];
-		if (Wr == 1'b1) begin
-			RegD[Rd_Addr_r]	<= Data_In;
-			RegR[Rd_Addr_r]	<= Data_In;
-			if (Rd_Addr_r == Rd_Addr) begin
-				Rd_Data	<= Data_In;
-			end
-			if (Rd_Addr_r == Rr_Addr) begin
-				Rr_Data	<= Data_In;
-			end
-			if (Rd_Addr_r == 5'b11110) begin
-				Z[7:0]	<= Data_In;
-			end
-			if (Rd_Addr_r == 5'b11111) begin
-				Z[15:8]	<= Data_In;
-			end
+		if (Wr) RAMD[RAM_Write_Address] <= Data_In;
+		RAMD_Out <= RAMD[Rd_Addr];
+	end
+
+	// RAM R
+	reg [7:0] RAMR [31:0];
+	reg [7:0] RAMR_Out;
+
+	always @(posedge Clk) begin
+		if (Wr) RAMR[RAM_Write_Address] <= Data_In;
+		RAMR_Out <= RAMR[Rr_Addr];
+	end
+
+	// Bypass
+	reg [7:0] Write_Data;
+	reg Bypass_D;
+	reg Bypass_R;
+	always @(posedge Clk) begin
+		Bypass_D <= Wr & (RAM_Write_Address == Rd_Addr);
+		Bypass_R <= Wr & (RAM_Write_Address == Rr_Addr);
+		Write_Data <= Data_In;
+	end
+
+	assign Rd_Data = Bypass_D? Write_Data : RAMD_Out;
+	assign Rr_Data = Bypass_R? Write_Data : RAMR_Out;
+
+	// Z Register
+	always @(posedge Clk) begin
+		if (Wr & RAM_Write_Address == 5'b11110) begin
+			Z[7:0]	<= Data_In;
+		end
+		if (Wr & RAM_Write_Address == 5'b11111) begin
+			Z[15:8]	<= Data_In;
 		end
 	end
 endmodule

--- a/verilator/hdl/mf8_reg.v
+++ b/verilator/hdl/mf8_reg.v
@@ -1,46 +1,66 @@
 /*
  * Copyright 2018 MicroFPGA UG
+ * Copyright 2019 The Regents of the University of California
  * Apache 2.0 License
  */
 
 
-module mf8_reg(Clk, Reset_n, Wr, Rd_Addr, Rr_Addr, Data_In, Rd_Data, Rr_Data, Z);
-	input	Clk;
-	input	Reset_n;
-	input	Wr;
-	input	[4:0]	Rd_Addr;
-	input	[4:0]	Rr_Addr;
-	input	[7:0]	Data_In;
-	output	[7:0]	Rd_Data;
-	reg	[7:0]	Rd_Data;
-	output	[7:0]	Rr_Data;
-	reg	[7:0]	Rr_Data;
-	output	[15:0]	Z;
-	reg	[15:0]	Z;	
+module mf8_reg(Clk, Reset, Wr, Rd_Addr, Rr_Addr, Data_In, Rd_Data, Rr_Data, Z);
+	input Clk;
+	input Reset;
+	input Wr;
+	input [4:0] Rd_Addr;
+	input [4:0] Rr_Addr;
+	input [7:0] Data_In;
+	output [7:0] Rd_Data;
+	output [7:0] Rr_Data;
+	output [15:0] Z;
+	reg    [15:0] Z;
 
-	reg 	[7:0]	RegD	[31:0];
-	reg 	[7:0]	RegR	[31:0];
-	reg 	[4:0]	Rd_Addr_r;
+	// Write Address Buffer
+	reg [4:0] RAM_Write_Address;
+	always @(posedge Clk) begin
+		RAM_Write_Address <= Rd_Addr;
+	end
+
+	// RAM D
+	reg [7:0] RAMD [31:0];
+	reg [7:0] RAMD_Out;
 
 	always @(posedge Clk) begin
-		Rd_Addr_r	<= Rd_Addr;
-		Rd_Data	<= RegD[Rd_Addr];
-		Rr_Data	<= RegR[Rr_Addr];
-		if (Wr == 1'b1) begin
-			RegD[Rd_Addr_r]	<= Data_In;
-			RegR[Rd_Addr_r]	<= Data_In;
-			if (Rd_Addr_r == Rd_Addr) begin
-				Rd_Data	<= Data_In;
-			end
-			if (Rd_Addr_r == Rr_Addr) begin
-				Rr_Data	<= Data_In;
-			end
-			if (Rd_Addr_r == 5'b11110) begin
-				Z[7:0]	<= Data_In;
-			end
-			if (Rd_Addr_r == 5'b11111) begin
-				Z[15:8]	<= Data_In;
-			end
+		if (Wr) RAMD[RAM_Write_Address] <= Data_In;
+		RAMD_Out <= RAMD[Rd_Addr];
+	end
+
+	// RAM R
+	reg [7:0] RAMR [31:0];
+	reg [7:0] RAMR_Out;
+
+	always @(posedge Clk) begin
+		if (Wr) RAMR[RAM_Write_Address] <= Data_In;
+		RAMR_Out <= RAMR[Rr_Addr];
+	end
+
+	// Bypass
+	reg [7:0] Write_Data;
+	reg Bypass_D;
+	reg Bypass_R;
+	always @(posedge Clk) begin
+		Bypass_D <= Wr & (RAM_Write_Address == Rd_Addr);
+		Bypass_R <= Wr & (RAM_Write_Address == Rr_Addr);
+		Write_Data <= Data_In;
+	end
+
+	assign Rd_Data = Bypass_D? Write_Data : RAMD_Out;
+	assign Rr_Data = Bypass_R? Write_Data : RAMR_Out;
+
+	// Z Register
+	always @(posedge Clk) begin
+		if (Wr & RAM_Write_Address == 5'b11110) begin
+			Z[7:0]	<= Data_In;
+		end
+		if (Wr & RAM_Write_Address == 5'b11111) begin
+			Z[15:8]	<= Data_In;
 		end
 	end
 endmodule

--- a/verilator/hdl_mss/mf8_reg.v
+++ b/verilator/hdl_mss/mf8_reg.v
@@ -1,46 +1,66 @@
 /*
  * Copyright 2018 MicroFPGA UG
+ * Copyright 2019 The Regents of the University of California
  * Apache 2.0 License
  */
 
 
-module mf8_reg(Clk, Reset_n, Wr, Rd_Addr, Rr_Addr, Data_In, Rd_Data, Rr_Data, Z);
-	input	Clk;
-	input	Reset_n;
-	input	Wr;
-	input	[4:0]	Rd_Addr;
-	input	[4:0]	Rr_Addr;
-	input	[7:0]	Data_In;
-	output	[7:0]	Rd_Data;
-	reg	[7:0]	Rd_Data;
-	output	[7:0]	Rr_Data;
-	reg	[7:0]	Rr_Data;
-	output	[15:0]	Z;
-	reg	[15:0]	Z;	
+module mf8_reg(Clk, Reset, Wr, Rd_Addr, Rr_Addr, Data_In, Rd_Data, Rr_Data, Z);
+	input Clk;
+	input Reset;
+	input Wr;
+	input [4:0] Rd_Addr;
+	input [4:0] Rr_Addr;
+	input [7:0] Data_In;
+	output [7:0] Rd_Data;
+	output [7:0] Rr_Data;
+	output [15:0] Z;
+	reg    [15:0] Z;
 
-	reg 	[7:0]	RegD	[31:0];
-	reg 	[7:0]	RegR	[31:0];
-	reg 	[4:0]	Rd_Addr_r;
+	// Write Address Buffer
+	reg [4:0] RAM_Write_Address;
+	always @(posedge Clk) begin
+		RAM_Write_Address <= Rd_Addr;
+	end
+
+	// RAM D
+	reg [7:0] RAMD [31:0];
+	reg [7:0] RAMD_Out;
 
 	always @(posedge Clk) begin
-		Rd_Addr_r	<= Rd_Addr;
-		Rd_Data	<= RegD[Rd_Addr];
-		Rr_Data	<= RegR[Rr_Addr];
-		if (Wr == 1'b1) begin
-			RegD[Rd_Addr_r]	<= Data_In;
-			RegR[Rd_Addr_r]	<= Data_In;
-			if (Rd_Addr_r == Rd_Addr) begin
-				Rd_Data	<= Data_In;
-			end
-			if (Rd_Addr_r == Rr_Addr) begin
-				Rr_Data	<= Data_In;
-			end
-			if (Rd_Addr_r == 5'b11110) begin
-				Z[7:0]	<= Data_In;
-			end
-			if (Rd_Addr_r == 5'b11111) begin
-				Z[15:8]	<= Data_In;
-			end
+		if (Wr) RAMD[RAM_Write_Address] <= Data_In;
+		RAMD_Out <= RAMD[Rd_Addr];
+	end
+
+	// RAM R
+	reg [7:0] RAMR [31:0];
+	reg [7:0] RAMR_Out;
+
+	always @(posedge Clk) begin
+		if (Wr) RAMR[RAM_Write_Address] <= Data_In;
+		RAMR_Out <= RAMR[Rr_Addr];
+	end
+
+	// Bypass
+	reg [7:0] Write_Data;
+	reg Bypass_D;
+	reg Bypass_R;
+	always @(posedge Clk) begin
+		Bypass_D <= Wr & (RAM_Write_Address == Rd_Addr);
+		Bypass_R <= Wr & (RAM_Write_Address == Rr_Addr);
+		Write_Data <= Data_In;
+	end
+
+	assign Rd_Data = Bypass_D? Write_Data : RAMD_Out;
+	assign Rr_Data = Bypass_R? Write_Data : RAMR_Out;
+
+	// Z Register
+	always @(posedge Clk) begin
+		if (Wr & RAM_Write_Address == 5'b11110) begin
+			Z[7:0]	<= Data_In;
+		end
+		if (Wr & RAM_Write_Address == 5'b11111) begin
+			Z[15:8]	<= Data_In;
 		end
 	end
 endmodule


### PR DESCRIPTION
Lattice was essentially implicitly instanciating
the Write_Data, Bypass_D and Bypass_R registers
and adding the apropriate muxes.

Now that the register bypass is explcit, there should
be no more race conditions (i.e. concurrent <= assignments)
and yosys is able to infer the correct RAM.

Let me know if you are interested in this change.